### PR TITLE
Fix shortcut for QuickBMS scripts dir

### DIFF
--- a/bucket/quickbms.json
+++ b/bucket/quickbms.json
@@ -30,10 +30,23 @@
             "quickbms_4gb_files.exe",
             "QuickBMS/QuickBMS (4GB Files)",
             "-G"
-        ],
-        [
-            "scripts",
-            "QuickBMS/QuickBMS Scripts"
         ]
+    ],
+    "post_install": [
+        "Write-Host ('{0}Creating shortcut for QuickBMS/QuickBMS Scripts (scripts)' -f [char]10)",
+        "$ws = New-Object -ComObject WScript.Shell",
+        "$sm = [Environment]::GetFolderPath(@('Common')[!$global] + 'StartMenu')",
+        "$ws = $ws.CreateShortcut($sm + '/Programs/Scoop Apps/QuickBMS/QuickBMS Scripts.lnk')",
+        "$ws.TargetPath = 'explorer'",
+        "$ws.Arguments = '{0}{1}{2}scripts{0}' -f [char]34, $dir, [char]92",
+        "$ws.IconLocation = $dir + [char]92 + 'quickbms.exe'",
+        "$ws.Save()"
+    ],
+    "post_uninstall": [
+        "$sm = [Environment]::GetFolderPath(@('Common')[!$global] + 'StartMenu')",
+        "$ln = [IO.Path]::Combine($sm, 'Programs', 'Scoop Apps', 'QuickBMS', 'QuickBMS Scripts.lnk')",
+        "Write-Host ('{0}Removing shortcut {0}' -f [char]10, $ln.Replace($env:USERPROFILE, '~'))",
+        "try { [IO.File]::Delete($ln) }catch{}",
+        "try { [IO.Directory]::Delete($ln + '/..') }catch{}"
     ]
 }


### PR DESCRIPTION
Because Scoop uses the `[IO.FileInfo]` class for `$target`, shortcut creation fails when targeting directories. (See [lib/shortcuts.ps1#L32](https://github.com/ScoopInstaller/Scoop/blob/b588a06e41d920d2123ec70aee682bae14935939/lib/shortcuts.ps1#L32))

So I changed the bucket to do this manually, and I tested it. Everything works and I made the output messages look just like they would if directory shortcuts weren't an issue

I formatted the code to avoid using backslashes or quotes to prevent any need for escaping with backslashes.

I know you don't use Windows anymore, so you might just have to take my word for it.